### PR TITLE
chore: typo in password type

### DIFF
--- a/cvat-ui/src/components/signing-common/cvat-signing-input.tsx
+++ b/cvat-ui/src/components/signing-common/cvat-signing-input.tsx
@@ -19,7 +19,7 @@ interface SocialAccountLinkProps {
 
 export enum CVATInputType {
     TEXT = 'text',
-    PASSWORD = 'passord',
+    PASSWORD = 'password',
 }
 
 function CVATSigningInput(props: SocialAccountLinkProps): JSX.Element {


### PR DESCRIPTION
There was a small typo in field types: changed passord to password